### PR TITLE
fix(gsd): use system date for all document timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Date handling**: Documents now use system date via `date` command instead of AI-inferred dates. Fixes incorrect dates in PROJECT.md, REQUIREMENTS.md, CONTEXT.md, codebase maps, and UAT timestamps. ([#XX](link))
+
 ## [1.0.0] - 2026-01-25
 
 ### Added

--- a/src/agents/gsd-codebase-mapper.md
+++ b/src/agents/gsd-codebase-mapper.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: gsd-codebase-mapper
 description: Explores codebase and writes structured analysis documents. Spawned by map-codebase with a focus area (tech, arch, quality, concerns). Writes documents directly to reduce orchestrator context load.
 tools:
@@ -20,6 +20,8 @@ You are spawned by `/gsd-map-codebase` with one of four focus areas:
 - **concerns**: Identify technical debt and issues → write CONCERNS.md
 
 Your job: Explore thoroughly, then write document(s) directly. Return confirmation only.
+
+**Dates:** Your prompt includes `<current_date>`. Use that exact date for Analysis Date in output documents (e.g. STRUCTURE.md, CONCERNS.md). Never guess or infer. See `references/date-handling.md`.
 </role>
 
 <why_this_matters>

--- a/src/agents/gsd-roadmapper.md
+++ b/src/agents/gsd-roadmapper.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: gsd-roadmapper
 description: Creates project roadmaps with phase breakdown, requirement mapping, success criteria derivation, and coverage validation. Spawned by /gsd-new-project orchestrator.
 tools:
@@ -26,6 +26,8 @@ Your job: Transform requirements into a phase structure that delivers the projec
 - Create success criteria (2-5 observable behaviors per phase)
 - Initialize STATE.md (project memory)
 - Return structured draft for user approval
+
+**Dates:** Your prompt includes `<current_date>`. Use that exact date for STATE.md, REQUIREMENTS.md traceability, and any [date] placeholders. Never guess or infer. See `references/date-handling.md`.
 </role>
 
 <downstream_consumer>

--- a/src/commands/gsd/map-codebase.md
+++ b/src/commands/gsd/map-codebase.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: gsd-map-codebase
 description: Analyze codebase with parallel mapper agents to produce .planning/codebase/ documents
 argument-hint: "[optional: specific area to map, e.g., 'api' or 'auth']"
@@ -21,6 +21,7 @@ Output: .planning/codebase/ folder with 7 structured documents about the codebas
 
 <execution_context>
 @~/.cursor/get-shit-done/workflows/map-codebase.md
+@~/.cursor/get-shit-done/references/date-handling.md
 </execution_context>
 
 <context>

--- a/src/commands/gsd/new-project.md
+++ b/src/commands/gsd/new-project.md
@@ -1,4 +1,4 @@
-﻿---
+---
 name: gsd-new-project
 description: Initialize a new project with deep context gathering and PROJECT.md
 tools:
@@ -31,6 +31,7 @@ This is the most leveraged moment in any project. Deep questioning here means be
 
 @~/.cursor/get-shit-done/references/questioning.md
 @~/.cursor/get-shit-done/references/ui-brand.md
+@~/.cursor/get-shit-done/references/date-handling.md
 @~/.cursor/get-shit-done/templates/project.md
 @~/.cursor/get-shit-done/templates/requirements.md
 
@@ -147,6 +148,8 @@ Loop until "Create PROJECT.md" selected.
 
 ## Phase 4: Write PROJECT.md
 
+**Before writing:** Run `date +%Y-%m-%d` and capture the output. Use that exact value for the Last updated footer. See `references/date-handling.md`.
+
 Synthesize all context into `.planning/PROJECT.md` using the template from `templates/project.md`.
 
 **For greenfield projects:**
@@ -213,12 +216,7 @@ Initialize with any decisions made during questioning:
 | [Choice from questioning] | [Why] | — Pending |
 ```
 
-**Last updated footer:**
-
-```markdown
----
-*Last updated: [date] after initialization*
-```
+**Last updated footer:** Use the date from `date +%Y-%m-%d` (run before writing). Format: `*Last updated: YYYY-MM-DD after initialization*`
 
 Do not compress. Capture everything gathered.
 
@@ -421,6 +419,14 @@ Create research directory:
 mkdir -p .planning/research
 ```
 
+**Get current date for subagents:** Run `date +%Y-%m-%d` and capture the output. Include in each Task prompt:
+```
+<current_date>
+Current date: [output from date command]
+Use this exact date for any [date] placeholders in output files. Never guess.
+</current_date>
+```
+
 **Determine milestone context:**
 
 Check if this is greenfield or subsequent milestone:
@@ -440,6 +446,11 @@ Spawn 4 parallel gsd-project-researcher agents with rich context:
 
 ```
 Task(prompt="First, read ~/.cursor/agents/gsd-project-researcher.md for your role and instructions.
+
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d — run before spawning]
+Use this exact date for any [date] placeholders in output. Never guess.
+</current_date>
 
 <research_type>
 Project Research — Stack dimension for [domain].
@@ -481,6 +492,11 @@ Use template: ~/.cursor/get-shit-done/templates/research-project/STACK.md
 
 Task(prompt="First, read ~/.cursor/agents/gsd-project-researcher.md for your role and instructions.
 
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for any [date] placeholders in output. Never guess.
+</current_date>
+
 <research_type>
 Project Research — Features dimension for [domain].
 </research_type>
@@ -520,6 +536,11 @@ Use template: ~/.cursor/get-shit-done/templates/research-project/FEATURES.md
 ", subagent_type="general-purpose", model="{researcher_model}", description="Features research")
 
 Task(prompt="First, read ~/.cursor/agents/gsd-project-researcher.md for your role and instructions.
+
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for any [date] placeholders in output. Never guess.
+</current_date>
 
 <research_type>
 Project Research — Architecture dimension for [domain].
@@ -561,6 +582,11 @@ Use template: ~/.cursor/get-shit-done/templates/research-project/ARCHITECTURE.md
 
 Task(prompt="First, read ~/.cursor/agents/gsd-project-researcher.md for your role and instructions.
 
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for any [date] placeholders in output. Never guess.
+</current_date>
+
 <research_type>
 Project Research — Pitfalls dimension for [domain].
 </research_type>
@@ -600,10 +626,15 @@ Use template: ~/.cursor/get-shit-done/templates/research-project/PITFALLS.md
 ", subagent_type="general-purpose", model="{researcher_model}", description="Pitfalls research")
 ```
 
-After all 4 agents complete, spawn synthesizer to create SUMMARY.md:
+After all 4 agents complete, spawn synthesizer to create SUMMARY.md. Include current date (from `date +%Y-%m-%d`) in the prompt:
 
 ```
 Task(prompt="
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for any [date] placeholders in SUMMARY.md. Never guess.
+</current_date>
+
 <task>
 Synthesize research outputs into SUMMARY.md.
 </task>
@@ -724,6 +755,8 @@ Use AskUserQuestion:
 
 Cross-check requirements against Core Value from PROJECT.md. If gaps detected, surface them.
 
+**Before generating REQUIREMENTS.md:** Run `date +%Y-%m-%d` and capture the output. Use for Defined and Last updated fields.
+
 **Generate REQUIREMENTS.md:**
 
 Create `.planning/REQUIREMENTS.md` with:
@@ -786,6 +819,8 @@ EOF
 
 ## Phase 8: Create Roadmap
 
+**Before spawning:** Run `date +%Y-%m-%d` and capture the output. Include in the roadmapper prompt (subagents do not receive user_info).
+
 Display stage banner:
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -799,6 +834,11 @@ Spawn gsd-roadmapper agent with context:
 
 ```
 Task(prompt="
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for STATE.md, REQUIREMENTS.md traceability, and any [date] placeholders. Never guess.
+</current_date>
+
 <planning_context>
 
 **Project:**

--- a/src/references/date-handling.md
+++ b/src/references/date-handling.md
@@ -1,0 +1,78 @@
+# GSD Date Handling
+
+**Purpose:** Ensure all dates in GSD documents are correct. AI models often hallucinate or miscalculate dates. This reference mandates programmatic date resolution.
+
+---
+
+## Rule: Never Guess the Date
+
+When writing any GSD document that includes a date (Last updated, Defined, Gathered, Analysis Date, etc.):
+
+1. **Run the date command first** — Do not infer, estimate, or use training data.
+2. **Use the exact output** — Copy the command output verbatim into the document.
+3. **Pass to subagents** — Subagents do not receive user_info; include the current date in their prompt.
+
+---
+
+## Commands to Use
+
+| Format | Command | Example Output | Use For |
+|--------|---------|----------------|---------|
+| ISO (YYYY-MM-DD) | `date +%Y-%m-%d` | 2025-02-19 | Traceability, Defined, footers |
+| Human-readable | `date "+%B %d, %Y"` | February 19, 2025 | Last updated, Gathered |
+| ISO timestamp | `date -u +%Y-%m-%dT%H:%M:%SZ` | 2025-02-19T14:30:00Z | UAT frontmatter, timestamps |
+
+**Run before writing.** Example:
+
+```bash
+date +%Y-%m-%d
+# Output: 2025-02-19
+```
+
+Then use `2025-02-19` exactly in the document.
+
+---
+
+## Where Dates Appear
+
+| Document | Field | Format |
+|----------|-------|--------|
+| PROJECT.md | Last updated | `*Last updated: [date] after [trigger]*` |
+| REQUIREMENTS.md | Defined, Last updated | `**Defined:** [date]`, `*Last updated: [date]*` |
+| ROADMAP.md | (if any) | Same as above |
+| STATE.md | Project Reference | `updated [date]` |
+| CONTEXT.md | Gathered | `**Gathered:** [date]` |
+| Research files | (if any) | ISO or human-readable |
+| UAT.md | frontmatter.updated | ISO timestamp |
+| Codebase map | Analysis Date | `**Analysis Date:** YYYY-MM-DD` |
+
+---
+
+## For Orchestrators (Spawning Subagents)
+
+Subagents do **not** receive `user_info` (including "Today's date"). You must pass the date explicitly.
+
+**Before spawning any subagent that will write documents:**
+
+1. Run: `date +%Y-%m-%d` (or `date "+%B %d, %Y"` for human format)
+2. Capture the output
+3. Include in the Task prompt:
+
+```
+<current_date>
+Current date: 2025-02-19
+Use this exact date for all [date] placeholders, Last updated, Defined, Gathered, etc. Never guess or infer.
+</current_date>
+```
+
+Replace `2025-02-19` with the actual output from step 1.
+
+---
+
+## Checklist
+
+Before writing any document with date fields:
+
+- [ ] Ran `date +%Y-%m-%d` (or appropriate format)
+- [ ] Used the exact output — no rounding, no "approximately"
+- [ ] If spawning subagents: included `<current_date>` block in their prompt

--- a/src/templates/project.md
+++ b/src/templates/project.md
@@ -1,4 +1,4 @@
-﻿# PROJECT.md Template
+# PROJECT.md Template
 
 Template for `.planning/PROJECT.md` — the living project context document.
 
@@ -121,6 +121,7 @@ Common types: Tech stack, Timeline, Budget, Dependencies, Compatibility, Perform
 - Always note when and why the document was updated
 - Format: `after Phase 2` or `after v1.0 milestone`
 - Triggers review of whether content is still accurate
+- **Date:** Run `date +%Y-%m-%d` before writing. Use that exact output — never guess. See `references/date-handling.md`
 
 </guidelines>
 

--- a/src/workflows/complete-milestone.md
+++ b/src/workflows/complete-milestone.md
@@ -1,4 +1,4 @@
-﻿<purpose>
+<purpose>
 
 Mark a shipped version (v1.0, v1.1, v2.0) as complete. This creates a historical record in MILESTONES.md, performs full PROJECT.md evolution review, reorganizes ROADMAP.md with milestone groupings, and tags the release in git.
 
@@ -274,11 +274,11 @@ cat .planning/phases/*-*/*-SUMMARY.md
 
 **Update PROJECT.md:**
 
-Make all edits inline. Update "Last updated" footer:
+Make all edits inline. Update "Last updated" footer. **Before writing:** Run `date +%Y-%m-%d` and use that exact output. See `references/date-handling.md`.
 
 ```markdown
 ---
-*Last updated: [date] after v[X.Y] milestone*
+*Last updated: YYYY-MM-DD after v[X.Y] milestone*
 ```
 
 **Example full evolution (v1.0 → v1.1 prep):**

--- a/src/workflows/discuss-phase.md
+++ b/src/workflows/discuss-phase.md
@@ -1,4 +1,4 @@
-﻿<purpose>
+<purpose>
 Extract implementation decisions that downstream agents need. Analyze the phase to identify gray areas, let the user choose what to discuss, then deep-dive each selected area until satisfied.
 
 You are a thinking partner, not an interviewer. The user is the visionary — you are the builder. Your job is to capture decisions that will guide research and planning, not to figure out implementation yourself.
@@ -294,6 +294,8 @@ fi
 ```
 
 **File location:** `${PHASE_DIR}/${PADDED_PHASE}-CONTEXT.md`
+
+**Before writing:** Run `date +%Y-%m-%d` and use that exact output for Gathered and Context gathered. Never guess. See `references/date-handling.md`.
 
 **Structure the content by what was discussed:**
 

--- a/src/workflows/map-codebase.md
+++ b/src/workflows/map-codebase.md
@@ -1,4 +1,4 @@
-﻿<purpose>
+<purpose>
 Orchestrate parallel codebase mapper agents to analyze codebase and produce structured documents in .planning/codebase/
 
 Each agent has fresh context, explores a specific focus area, and **writes documents directly**. The orchestrator only receives confirmation + line counts, then writes a summary.
@@ -91,6 +91,8 @@ Continue to spawn_agents.
 <step name="spawn_agents">
 Spawn 4 parallel gsd-codebase-mapper agents.
 
+**Before spawning:** Run `date +%Y-%m-%d` and capture the output. Include in each Task prompt — subagents do not receive user_info. Use for Analysis Date in output documents. See `references/date-handling.md`.
+
 Use Task tool with `subagent_type="gsd-codebase-mapper"`, `model="{mapper_model}"`, and `run_in_background=true` for parallel execution.
 
 **CRITICAL:** Use the dedicated `gsd-codebase-mapper` agent, NOT `Explore`. The mapper agent writes documents directly.
@@ -107,6 +109,11 @@ description: "Map codebase tech stack"
 
 Prompt:
 ```
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for Analysis Date in output documents. Never guess.
+</current_date>
+
 Focus: tech
 
 Analyze this codebase for technology stack and external integrations.
@@ -130,6 +137,11 @@ description: "Map codebase architecture"
 
 Prompt:
 ```
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for Analysis Date in output documents. Never guess.
+</current_date>
+
 Focus: arch
 
 Analyze this codebase architecture and directory structure.
@@ -153,6 +165,11 @@ description: "Map codebase conventions"
 
 Prompt:
 ```
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for Analysis Date in output documents. Never guess.
+</current_date>
+
 Focus: quality
 
 Analyze this codebase for coding conventions and testing patterns.
@@ -176,6 +193,11 @@ description: "Map codebase concerns"
 
 Prompt:
 ```
+<current_date>
+Current date: [INJECT: output from date +%Y-%m-%d]
+Use this exact date for Analysis Date in output documents. Never guess.
+</current_date>
+
 Focus: concerns
 
 Analyze this codebase for technical debt, known issues, and areas of concern.

--- a/src/workflows/transition.md
+++ b/src/workflows/transition.md
@@ -1,4 +1,4 @@
-﻿<required_reading>
+<required_reading>
 
 **read these files NOW:**
 
@@ -195,11 +195,11 @@ cat .planning/phases/XX-current/*-SUMMARY.md
 
 **Update PROJECT.md:**
 
-Make the edits inline. Update "Last updated" footer:
+Make the edits inline. Update "Last updated" footer. **Before writing:** Run `date +%Y-%m-%d` and use that exact output. See `references/date-handling.md`.
 
 ```markdown
 ---
-*Last updated: [date] after Phase [X]*
+*Last updated: YYYY-MM-DD after Phase [X]*
 ```
 
 **Example evolution:**

--- a/src/workflows/verify-work.md
+++ b/src/workflows/verify-work.md
@@ -1,4 +1,4 @@
-﻿<purpose>
+<purpose>
 Validate built features through conversational testing with persistent state. Creates UAT.md that tracks test progress, survives /clear, and feeds gaps into /gsd-plan-phase --gaps.
 
 User tests, Claude records. One test at a time. Plain text responses.
@@ -140,8 +140,8 @@ Create file:
 status: testing
 phase: XX-name
 source: [list of SUMMARY.md files]
-started: [ISO timestamp]
-updated: [ISO timestamp]
+started: [ISO timestamp - run: date -u +%Y-%m-%dT%H:%M:%SZ]
+updated: [ISO timestamp - run: date -u +%Y-%m-%dT%H:%M:%SZ]
 ---
 
 ## Current Test
@@ -264,7 +264,7 @@ Append to Gaps section (structured YAML for plan-phase --gaps):
 **After any response:**
 
 Update Summary counts.
-Update frontmatter.updated timestamp.
+Update frontmatter.updated timestamp: run `date -u +%Y-%m-%dT%H:%M:%SZ` and use that exact value. See `references/date-handling.md`.
 
 If more tests remain → Update Current Test, go to `present_test`
 If no more tests → Go to `complete_session`
@@ -295,7 +295,7 @@ Proceed to `present_test`.
 
 Update frontmatter:
 - status: complete
-- updated: [now]
+- updated: [run `date -u +%Y-%m-%dT%H:%M:%SZ` for exact ISO timestamp]
 
 Clear Current Test section:
 ```


### PR DESCRIPTION
## Problem
GSD documents (PROJECT.md, REQUIREMENTS.md, CONTEXT.md, codebase maps, etc.) use `[date]` placeholders that the AI fills in. The dates are often wrong because models infer or hallucinate instead of using the actual date.

## Solution
1. **New reference** (`references/date-handling.md`): Rules for date handling, commands to run, and how to pass dates to subagents.
2. **Orchestrators**: Before writing or spawning, run `date +%Y-%m-%d` (or the right format) and use that output.
3. **Subagents**: Orchestrators inject `<current_date>` into prompts, since subagents don't receive `user_info`.

## Changes
- **Commands**: new-project, map-codebase — date instructions and `<current_date>` in all spawns
- **Workflows**: discuss-phase, transition, complete-milestone, verify-work — run date before writing
- **Agents**: roadmapper, codebase-mapper — use `current_date` from prompt
- **Templates**: project.md — added date-handling note to Last Updated

## Testing
- Run `/gsd-new-project` and confirm PROJECT.md, REQUIREMENTS.md, ROADMAP.md, STATE.md use correct dates
- Run `/gsd-map-codebase` and confirm codebase docs use correct Analysis Date

Fixes #1 