### PR TITLE
fix: use ~/.cursor/ instead of ~/.claude/ in hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hooks**: Corrected path references from `~/.claude/` to `~/.cursor/` in `gsd-check-update.js` and `gsd-statusline.js`. The hooks were still pointing to Claude Code's config directory, causing cache and VERSION file lookups to fail on Cursor.
+
 ## [1.0.0] - 2026-01-25
 
 ### Added

--- a/src/hooks/gsd-check-update.js
+++ b/src/hooks/gsd-check-update.js
@@ -9,12 +9,12 @@ const { spawn } = require('child_process');
 
 const homeDir = os.homedir();
 const cwd = process.cwd();
-const cacheDir = path.join(homeDir, '.claude', 'cache');
+const cacheDir = path.join(homeDir, '.cursor', 'cache');
 const cacheFile = path.join(cacheDir, 'gsd-update-check.json');
 
 // VERSION file locations (check project first, then global)
-const projectVersionFile = path.join(cwd, '.claude', 'get-shit-done', 'VERSION');
-const globalVersionFile = path.join(homeDir, '.claude', 'get-shit-done', 'VERSION');
+const projectVersionFile = path.join(cwd, '.cursor', 'get-shit-done', 'VERSION');
+const globalVersionFile = path.join(homeDir, '.cursor', 'get-shit-done', 'VERSION');
 
 // Ensure cache directory exists
 if (!fs.existsSync(cacheDir)) {

--- a/src/hooks/gsd-statusline.js
+++ b/src/hooks/gsd-statusline.js
@@ -1,5 +1,5 @@
-﻿#!/usr/bin/env node
-// Claude Code Statusline - GSD Edition
+#!/usr/bin/env node
+// Cursor IDE Statusline - GSD Edition
 // Shows: model | current task | directory | context usage
 
 const fs = require('fs');
@@ -43,7 +43,7 @@ process.stdin.on('end', () => {
     // Current task from todos
     let task = '';
     const homeDir = os.homedir();
-    const todosDir = path.join(homeDir, '.claude', 'todos');
+    const todosDir = path.join(homeDir, '.cursor', 'todos');
     if (session && fs.existsSync(todosDir)) {
       const files = fs.readdirSync(todosDir)
         .filter(f => f.startsWith(session) && f.includes('-agent-') && f.endsWith('.json'))
@@ -61,7 +61,7 @@ process.stdin.on('end', () => {
 
     // GSD update available?
     let gsdUpdate = '';
-    const cacheFile = path.join(homeDir, '.claude', 'cache', 'gsd-update-check.json');
+    const cacheFile = path.join(homeDir, '.cursor', 'cache', 'gsd-update-check.json');
     if (fs.existsSync(cacheFile)) {
       try {
         const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));


### PR DESCRIPTION
The gsd-check-update.js and gsd-statusline.js hooks were still referencing Claude Code's config directory. This caused cache and VERSION file lookups to fail on Cursor IDE.